### PR TITLE
added check_mk mk-job support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,8 @@ class rsnapshot (
   $snapshot_root                 = $rsnapshot::params::config_snapshot_root,
   $backup_levels                 = $rsnapshot::params::config_backup_levels,
   $cron_service_name             = $rsnapshot::params::cron_service_name,
+  $check_mk_job                  = $rsnapshot::params::config_check_mk_job,
+  
 ) inherits rsnapshot::params {
 
   $default_backup_scripts = $rsnapshot::params::backup_scripts + $backup_scripts
@@ -32,4 +34,3 @@ class rsnapshot (
     contain '::rsnapshot::service'
   }
 }
-

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class rsnapshot::params {
   $config_backup_levels          = [ 'daily', 'weekly', 'monthly' ]
   $config_backup_defaults        = true
   $config_version                = '1.2'
+  $config_check_mk_job           = false
   $config_cmd_cp                 = '/bin/cp'
   $config_cmd_rm                 = '/bin/rm'
   $config_cmd_rsync              = '/usr/bin/rsync'
@@ -43,7 +44,7 @@ class rsnapshot::params {
   $config_loglevel               = '4'
   $config_stop_on_stale_lockfile = undef # bool
   $config_rsync_short_args       = '-az'
-  $config_rsync_long_args        = undef # defaults are --delete --numeric-ids --relative --delete-excluded 
+  $config_rsync_long_args        = undef # defaults are --delete --numeric-ids --relative --delete-excluded
   $config_ssh_args               = undef
   $config_du_args                = undef
   $config_one_fs                 = undef

--- a/templates/cron.erb
+++ b/templates/cron.erb
@@ -1,1 +1,1 @@
-<%= @minute %> <%= @hour %> <%= @monthday %> <%= @month %> <%= @weekday %>  root      /usr/bin/rsnapshot -c <%= @config %> <%= @level %>
+<%= @minute %> <%= @hour %> <%= @monthday %> <%= @month %> <%= @weekday %>  root<% if scope['rsnapshot::check_mk_job'] == true -%> mk-job rsnapshot_<%= @host %>_<%= @level %><% end -%>       /usr/bin/rsnapshot -c <%= @config %> <%= @level %>


### PR DESCRIPTION
check_mks mk-job command collects execution state and runtime statistics of cron jobs. Infos:
https://mathias-kettner.de/checkmk_job.html

Added a new param $config_check_mk_job to the params class.
If "check_mk_job => true" is set in a rsnapshot class the cron template will add the mk-job prefix to the cronjobs.
