### PR TITLE
Fix: monthday in cronjob cannot be 0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -96,7 +96,7 @@ class rsnapshot::params {
     monthly    => {
       minute   => '0..59',
       hour     => '0..23',      # you could also do:   ['21..23','0..4','5'],
-      monthday => '0..28',
+      monthday => '1..28',
       month    => '*',
       weekday  => '*',
     },


### PR DESCRIPTION
At least according to `man 5 cronjob` (and also Wikipedia ;) the day of month can only be 1-31. When the script created a cron.d file with a 0 at that position the script would not run at all.