### PR TITLE
Add missing one_fs_num variable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -103,6 +103,7 @@ class rsnapshot::config (
     if ! ( $interval and $retain ) {
       $interval             = pick($hash['interval'], $rsnapshot::params::config_interval)
     }
+
     # rsnapshot wants numeric values
     if $link_dest {
       $link_dest_num        = bool2num($link_dest)
@@ -112,6 +113,9 @@ class rsnapshot::config (
     }
     if $use_lazy_deletes {
       $use_lazy_deletes_num = bool2num($use_lazy_deletes)
+    }
+    if $one_fs {
+      $one_fs_num           = bool2num($one_fs)
     }
 
     $real_include = $rsnapshot::include + $include

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "loomsen-rsnapshot",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "author": "loomsen",
   "summary": "Configures rsnapshot.",
   "license": "Apache-2.0",


### PR DESCRIPTION
The `one_fs_num` variable is expected in the template but does not exist.