### PR TITLE
has_key is deprecated

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -143,7 +143,7 @@ class rsnapshot::config (
 
 
 
-    if has_key($hash, backup_scripts) {
+    if backup_scripts in $hash {
       $hash[backup_scripts].each |$script, $scriptconf| {
         $real_script       = deep_merge($rsnapshot::params::backup_scripts[$script], $rsnapshot::backup_scripts[$script], $hash[backup_scripts][$script])
         $dbbackup_user     = $real_script[dbbackup_user]


### PR DESCRIPTION
has_key is deprecated per: https://www.puppetmodule.info/modules/puppetlabs-stdlib/7.0.1/puppet_functions_ruby3x/has_key  This makes this compatible with the latest puppetlabs-stdlib